### PR TITLE
Fix changing selected shipping_rate not busting serializer cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 > Vendo ensures excellent buyer experience with smooth product discovery and search, a multitude of payment methods and optimal shipping cost calculation. Vendo keeps suppliers happy with easy onboarding, automated products sync using their preferred method and easy payouts.
 
-> [Start your 30-day free trial](https://e98esoirr8c.typeform.com/contactvendo?typeform-source=spree_github)
+> [Start your 14-day free trial](https://app.getvendo.com/users/new?typeform-source=spree_github)
 
 ---
 

--- a/api/docs/v2/storefront/index.yaml
+++ b/api/docs/v2/storefront/index.yaml
@@ -72,7 +72,7 @@ paths:
                     public_metadata:
                       type: object
                       example:
-                        user_segment: 'supplier'
+                        user_segment: supplier
                       description: The public metadata for this User
                     private_metadata:
                       type: object
@@ -399,10 +399,10 @@ paths:
               properties:
                 public_metadata:
                   type: object
-                  description: 'The public metadata for the cart.'
+                  description: The public metadata for the cart.
                 private_metadata:
                   type: object
-                  description: 'The private metadata for the cart.'
+                  description: The private metadata for the cart.
       summary: Create a Cart
     delete:
       description: |-
@@ -474,10 +474,10 @@ paths:
                   type: integer
                 public_metadata:
                   type: object
-                  description: 'The public metadata for the added item.'
+                  description: The public metadata for the added item.
                 private_metadata:
                   type: object
-                  description: 'The private metadata for the added item.'
+                  description: The private metadata for the added item.
                 options:
                   type: object
                   description: 'Additional custom options. Activate these by adding: `Spree::PermittedAttributes.line_item_attributes << :foo` in `config/initializers/spree.rb`'
@@ -949,7 +949,7 @@ paths:
                   description: ID of the selected Shipping Method
                 shipment_id:
                   type: string
-                  description: 'ID of the selected Shipment. If not supplied it will try to set selected shipping method for all shipments'
+                  description: ID of the selected Shipment. If not supplied it will try to set selected shipping method for all shipments
               required:
                 - shipping_method_id
             examples:
@@ -2668,7 +2668,7 @@ components:
               type: object
               example:
                 recommended_by_us: true
-              description: 'The public metadata for the Line Item.'
+              description: The public metadata for the Line Item.
         relationships:
           type: object
           properties:
@@ -3184,7 +3184,7 @@ components:
       x-internal: true
     Store:
       type: object
-      description: 'Stores are the center of the Spree ecosystem. Each Spree installation can have multiple Stores. Each Store operates on a different domain or subdomain.'
+      description: Stores are the center of the Spree ecosystem. Each Spree installation can have multiple Stores. Each Store operates on a different domain or subdomain.
       title: Store
       x-internal: true
       properties:
@@ -3227,19 +3227,19 @@ components:
               description: Indicates if the Store is the default one
             supported_currencies:
               type: string
-              example: EUR,USD,GBP
+              example: 'EUR,USD,GBP'
               description: All currencies supported by store
             facebook:
               type: string
-              example: https://www.facebook.com/mystorename
+              example: 'https://www.facebook.com/mystorename'
               description: URL of Facebook page
             twitter:
               type: string
-              example: https://twitter.com/mystorename
+              example: 'https://twitter.com/mystorename'
               description: URL of Twitter page
             instagram:
               type: string
-              example: https://instagram.com/mystorename
+              example: 'https://instagram.com/mystorename'
               description: URL of Instagram page
             default_locale:
               type: string
@@ -3247,7 +3247,7 @@ components:
               description: Default locale of the Store
             supported_locales:
               type: string
-              example: en,es,de
+              example: 'en,es,de'
               description: Supported locales of the Store
             customer_support_email:
               type: string
@@ -3259,7 +3259,7 @@ components:
               description: Description of the Store which is visible in the Footer
             address:
               type: string
-              example: 813 Howard Street, Oswego NY 13126, USA
+              example: '813 Howard Street, Oswego NY 13126, USA'
               description: Address of the Store which is visible in the Footer
             contact_phone:
               type: string
@@ -3267,7 +3267,7 @@ components:
               description: Contact phone number of the Store which is visible in the Footer
             favicon_path:
               type: string
-              example: '/assets/favicon.ico'
+              example: /assets/favicon.ico
         relationships:
           type: object
           properties:
@@ -3660,7 +3660,7 @@ components:
             public_metadata:
               type: object
               example:
-                user_segment: 'supplier'
+                user_segment: supplier
               description: The public metadata for this User
         relationships:
           type: object
@@ -5112,7 +5112,7 @@ components:
                     store_credits: 0
                     completed_orders: 0
                     public_metadata:
-                      user_segment: 'supplier'
+                      user_segment: supplier
                   relationships:
                     default_billing_address:
                       data:
@@ -6232,11 +6232,11 @@ components:
                     year: 2026
                     name: John Doe
                     default: true
-                    relationships:
-                      payment_method:
-                        data:
-                          id: '1'
-                          type: payment_method
+                  relationships:
+                    payment_method:
+                      data:
+                        id: '1'
+                        type: payment_method
                 included:
                   - id: '1'
                     type: payment_method
@@ -6281,11 +6281,11 @@ components:
                       year: 2026
                       name: John Doe
                       default: true
-                      relationships:
-                        payment_method:
-                          data:
-                            id: string
-                            type: string
+                    relationships:
+                      payment_method:
+                        data:
+                          id: string
+                          type: string
                   - id: '2'
                     type: credit_card
                     attributes:
@@ -6295,11 +6295,11 @@ components:
                       year: 2030
                       name: John Doe
                       default: false
-                      relationships:
-                        payment_method:
-                          data:
-                            id: string
-                            type: string
+                    relationships:
+                      payment_method:
+                        data:
+                          id: string
+                          type: string
                 included:
                   - id: '1'
                     type: payment_method
@@ -8580,28 +8580,28 @@ components:
                     seo_title: ''
                     default_currency: USD
                     default: true
-                    supported_currencies: EUR,GBP,USD
+                    supported_currencies: 'EUR,GBP,USD'
                     facebook: 'https://www.facebook.com/mystorename'
                     twitter: 'https://twitter.com/mystorename'
                     instagram: 'https://instagram.com/mystorename'
                     default_locale: en
-                    customer_support_email: 'support@mystore.com'
-                    description: 'Mystore has been selling luxury clothing for more than 20 years and has 15 stores currently.'
+                    customer_support_email: support@mystore.com
+                    description: Mystore has been selling luxury clothing for more than 20 years and has 15 stores currently.
                     address: '813 Howard Street, Oswego NY 13126, USA'
                     contact_phone: '+123456789'
                     supported_locales: en
-                    favicon_path: '/assets/favicon.ico'
+                    favicon_path: /assets/favicon.ico
                   relationships:
                     menus:
                       data:
-                      - id: '10'
-                        type: menu
-                      - id: '11'
-                        type: menu
+                        - id: '10'
+                          type: menu
+                        - id: '11'
+                          type: menu
                     cms_pages:
                       data:
-                      - id: '5'
-                        type: cms_page
+                        - id: '5'
+                          type: cms_page
                     default_country:
                       data:
                         id: '2'
@@ -8619,28 +8619,28 @@ components:
                     seo_title: ''
                     default_currency: USD
                     default: true
-                    supported_currencies: EUR,GBP,USD
+                    supported_currencies: 'EUR,GBP,USD'
                     facebook: 'https://www.facebook.com/mystorename'
                     twitter: 'https://twitter.com/mystorename'
                     instagram: 'https://instagram.com/mystorename'
                     default_locale: en
-                    customer_support_email: 'support@mystore.com'
-                    description: 'Mystore has been selling luxury clothing for more than 20 years and has 15 stores currently.'
+                    customer_support_email: support@mystore.com
+                    description: Mystore has been selling luxury clothing for more than 20 years and has 15 stores currently.
                     address: '813 Howard Street, Oswego NY 13126, USA'
                     contact_phone: '+123456789'
                     supported_locales: en
-                    favicon_path: '/assets/favicon.ico'
+                    favicon_path: /assets/favicon.ico
                   relationships:
                     menus:
                       data:
-                      - id: '10'
-                        type: menu
-                      - id: '11'
-                        type: menu
+                        - id: '10'
+                          type: menu
+                        - id: '11'
+                          type: menu
                     cms_pages:
                       data:
-                      - id: '5'
-                        type: cms_page
+                        - id: '5'
+                          type: cms_page
                     default_country:
                       data:
                         id: '2'
@@ -8663,12 +8663,12 @@ components:
                     type: cms_page
                     attributes:
                       title: Returns Policy
-                      content:
+                      content: null
                       locale: en
                       meta_description: ''
                       meta_title: ''
                       slug: returns-policy
-                      type: Spree::Cms::Pages::StandardPage
+                      type: 'Spree::Cms::Pages::StandardPage'
                     relationships:
                       cms_sections:
                         data: []
@@ -8681,10 +8681,10 @@ components:
                     relationships:
                       menu_items:
                         data:
-                        - id: '1'
-                          type: menu_item
-                        - id: '2'
-                          type: menu_item
+                          - id: '1'
+                            type: menu_item
+                          - id: '2'
+                            type: menu_item
     Taxon:
       description: 200 Success - Returns the `taxon` object.
       content:
@@ -16498,6 +16498,7 @@ tags:
   - name: Menus
   - name: Order Status
   - name: Products
+  - name: Stores
   - name: Taxons
   - name: Wishlists
   - name: Wishlists / Wished Items

--- a/core/app/models/concerns/spree/calculated_adjustments.rb
+++ b/core/app/models/concerns/spree/calculated_adjustments.rb
@@ -18,7 +18,7 @@ module Spree
 
       def calculator_type=(calculator_type)
         klass = calculator_type.constantize if calculator_type
-        self.calculator = klass.new if klass && !calculator.is_a?(klass)
+        self.calculator = klass.new if klass && !calculator.instance_of?(klass)
       end
 
       private

--- a/core/app/models/concerns/spree/product_scopes.rb
+++ b/core/app/models/concerns/spree/product_scopes.rb
@@ -339,7 +339,7 @@ module Spree
           case t
           when ApplicationRecord then t
           else
-            Taxon.where(name: t).or(Taxon.where(id: t)).or(Taxon.where("permalink LIKE ? OR permalink = ?", "%/#{t}/", "#{t}/")).first
+            Taxon.where(Taxon.arel_table[:name].eq(t)).or(Taxon.where(Taxon.arel_table[:id].eq(t))).or(Taxon.where(Taxon.arel_table[:permalink].matches("%/#{t}/"))).or(Taxon.where(Taxon.arel_table[:permalink].matches("#{t}/"))).first
           end
         end.compact.flatten.uniq
       end

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -250,6 +250,7 @@ module Spree
 
     def selected_shipping_rate_id=(id)
       shipping_rates.update_all(selected: false)
+      shipping_rates.touch_all # Bust cache dependent on "updated_at" timestamp
       shipping_rates.update(id, selected: true)
       save!
     end


### PR DESCRIPTION
## Expected Behavior
We expect to have only one shipping provider method for each shipment.

## Actual Behavior
Selecting shipping providers other than the one returned from the API as a default one for a user causes to have multiple shipping providers with the `selected: true` field returned.

Postman call for: /api/v2/storefront/checkout/shipping_rates after changing shipping method:
```
...
"included": [
        ...
        {
            "id": "<id 1>",
            "type": "shipping_rate",
            "attributes": {
                ...
                "selected": true,
            }
        },
        {
            "id": "<id 2>",
            "type": "shipping_rate",
            "attributes": {
                 ...
                "selected": true,
            }
        },
        {
            "id": "<id 3>",
            "type": "shipping_rate",
            "attributes": {
                ...
                "selected": false,
            }
        },
    ]
}
```
Only one method for each shipment should contain `"selected": true`.

## Steps to reproduce
1. Select any shipping provider
2. Continue to billing
3. Go back to the shipping
4. Select a different shipping provider than the one selected before
5. Request /api/v2/storefront/checkout/shipping_rates

## Cause
This issue is caused by faulty cache-busting in [Spree::V2::Storefront::EstimatedShippingRateSerializer](https://github.com/spree/spree/blob/main/api/app/serializers/spree/v2/storefront/estimated_shipping_rate_serializer.rb). JSONAPI serializers use the `updated_at` column as the key by default. `update_all` does not update the timestamps as it does not instantiate the models.

## Solution
Calling `touch_all` on the shipping rates after `update_all` fixes the issue.